### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/74c7b2b5-e610-46e6-9506-5a6234aea9df/a73d6751-5e0f-41db-96dd-e0d2528d9f24/_apis/work/boardbadge/df6b559d-58e4-46b3-9b80-b36512730cde)](https://dev.azure.com/aiw-devops/74c7b2b5-e610-46e6-9506-5a6234aea9df/_boards/board/t/a73d6751-5e0f-41db-96dd-e0d2528d9f24/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2961](https://dev.azure.com/aiw-devops/74c7b2b5-e610-46e6-9506-5a6234aea9df/_workitems/edit/2961). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.